### PR TITLE
Feat/23 preserve visits originating from the netherlands when filtering non production log entries

### DIFF
--- a/db/03-filter-prod.sql
+++ b/db/03-filter-prod.sql
@@ -12,7 +12,7 @@ DECLARE
 BEGIN
 	SELECT COUNT(DISTINCT(configuration))
        	INTO count_
-	FROM production_filtered
+	FROM production_filtered;
 	ASSERT count_ = 1, 'Non-production data present in table production_filtered';
 END
 $$

--- a/db/03-filter-prod.sql
+++ b/db/03-filter-prod.sql
@@ -1,7 +1,6 @@
 CREATE TABLE production_filtered AS (
 	SELECT * FROM logs
 	WHERE configuration = 'production'
-	AND client_country != 'Netherlands'
 );
 
 CREATE OR REPLACE FUNCTION check_prod_filter()
@@ -9,14 +8,12 @@ RETURNS void AS
 $$
 
 DECLARE
-        row_    RECORD;
 	count_  INTEGER;
 BEGIN
-	FOR row_ in
-		SELECT DISTINCT(configuration) FROM production_filtered
-	LOOP
-		ASSERT row_.configuration = 'production', 'Non-production data present in table production_filtered';
-	END LOOP;
+	SELECT COUNT(DISTINCT(configuration))
+       	INTO count_
+	FROM production_filtered
+	ASSERT count_ = 1, 'Non-production data present in table production_filtered';
 END
 $$
 LANGUAGE plpgsql;

--- a/db/03-filter-prod.sql
+++ b/db/03-filter-prod.sql
@@ -7,6 +7,7 @@ CREATE TABLE production_filtered AS (
 CREATE OR REPLACE FUNCTION check_prod_filter()
 RETURNS void AS
 $$
+
 DECLARE
         row_    RECORD;
 	count_  INTEGER;
@@ -16,12 +17,6 @@ BEGIN
 	LOOP
 		ASSERT row_.configuration = 'production', 'Non-production data present in table production_filtered';
 	END LOOP;
-
-	SELECT COUNT(*) FROM production_filtered
-	INTO count_
-	WHERE client_country = 'Netherlands';
-
-	ASSERT count_ = 0, 'Interactions from clients within the Netherlands are still in the logs';
 END
 $$
 LANGUAGE plpgsql;

--- a/db/04-separate-pages.sql
+++ b/db/04-separate-pages.sql
@@ -1,9 +1,9 @@
 CREATE TABLE production_filtered_login AS (
 	SELECT * FROM production_filtered
-	WHERE page = 'login'
+	WHERE operation_name = '/login'
 );
 
 CREATE TABLE production_filtered_dashboard AS (
 	SELECT * FROM production_filtered
-	WHERE page = 'dashboard'
+	WHERE operation_name = '/'
 );


### PR DESCRIPTION
### Changes
1. removal of `AND client_country = Netherlands` from the query that filters non-production data.
2. use of `operation_name = /` to filter down to dashboard interactions only.