### PR TITLE
Persist sorting when filters adjusted

### DIFF
--- a/server/views/scripts/visits/types.js
+++ b/server/views/scripts/visits/types.js
@@ -423,11 +423,22 @@ class Table {
                 create_filterstatus().
                 create_filter();
 
+            if (PageState["sortingActive"]) {
+                factory.create_sort();
+            }
+
             let urlBuilder = new URLBuilder(factory);
             let urlOrchestrator = new URLOrchestrator(urlBuilder);
-            let filterURL = urlOrchestrator.build_filtered_view_url().url;
+            var filterURL = null;
 
-            request(filterURL,Table.table_response_inspector,Table.show_filtered_view);
+            if (PageState["sortingActive"]) {
+                filterURL = urlOrchestrator.build_sorted_view_url().url;
+                request(filterURL,Table.table_response_inspector,Table.show_sorted_view);
+            }
+            else {
+                filterURL = urlOrchestrator.build_filtered_view_url().url;   
+                request(filterURL,Table.table_response_inspector,Table.show_filtered_view); 
+            } 
         }
 
         else {


### PR DESCRIPTION
This PR changes `filter_value_clicked` such that when sorting is active, a url for reaching the `sorted-view` endpoint is constructed and the response is handled by `show_sorted_view`.